### PR TITLE
Add GitHub Actions pipeline for Android CI/CD

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,116 @@
+name: Android CI/CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CI: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Android SDK components
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+
+      - name: Configure Gradle caching
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for Gradle wrapper
+        run: |
+          if [ -f gradlew ]; then
+            chmod +x gradlew
+          fi
+
+      - name: Run lint and unit tests
+        run: ./gradlew lint test
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload debug APK artifact
+        if: ${{ success() && hashFiles('app/build/outputs/apk/debug/*.apk') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+
+  release:
+    name: Release build
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    env:
+      CI: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Android SDK components
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+
+      - name: Configure Gradle caching
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for Gradle wrapper
+        run: |
+          if [ -f gradlew ]; then
+            chmod +x gradlew
+          fi
+
+      - name: Build release artifacts
+        run: ./gradlew assembleRelease bundleRelease
+
+      - name: Upload release artifacts for reference
+        if: ${{ success() && hashFiles('app/build/outputs/apk/release/*.apk', 'app/build/outputs/bundle/release/*.aab') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-packages
+          path: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
+
+      - name: Publish GitHub release
+        if: ${{ success() && hashFiles('app/build/outputs/apk/release/*.apk', 'app/build/outputs/bundle/release/*.aab') != '' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
+# Policy Switcher
 
+This repository ships with a GitHub Actions based CI/CD pipeline tailored for an Android application. The workflow lives in [`android-ci.yml`](.github/workflows/android-ci.yml) and automates build validation for every change as well as release packaging when version tags are pushed.
+
+## Workflow overview
+- **Build & Test (CI)** runs on pull requests, pushes to `main`, manual dispatches, and tag events. The job checks out the code, validates the Gradle wrapper, provisions JDK 17 and the Android SDK (API level 34 / Build Tools 34.0.0), enables Gradle caching, and then executes `./gradlew lint test assembleDebug`. The resulting debug APK is published as an artifact for quick download.
+- **Release build (CD)** is triggered only when a tag that starts with `v` is pushed. After reusing the same toolchain setup, it builds both `assembleRelease` and `bundleRelease`, uploads the generated APK/AAB artifacts, and publishes a GitHub release that includes those binaries.
+
+## Usage notes
+- Update the `api-level` and `build-tools` values in the workflow if your project targets a different Android SDK version.
+- The workflow assumes the presence of a Gradle wrapper (`gradlew`) and a standard `app` module structure for artifact paths. Adjust the Gradle tasks or artifact globs if your module name differs.
+- For signed releases, configure signing inside your Gradle scripts and expose the required credentials as encrypted repository secrets, then reference them in the workflow steps.
+- Trigger a release by creating and pushing a version tag (for example, `v1.0.0`). The workflow will automatically create a GitHub release with the packaged binaries.


### PR DESCRIPTION
## Summary
- add a reusable GitHub Actions workflow that builds, tests, and packages the Android app
- generate release artifacts and publish GitHub releases automatically when version tags are pushed
- document the pipeline structure and configuration options in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1c33ed6e4832c92e724d87bdf23a8